### PR TITLE
[Feat] paging3를 이용한 무한 스크롤 구현

### DIFF
--- a/app/src/main/java/com/yujin/rickandmorty/MainActivity.kt
+++ b/app/src/main/java/com/yujin/rickandmorty/MainActivity.kt
@@ -73,7 +73,7 @@ class MainActivity : ComponentActivity() {
                             entry<CharacterList> {
                                 CharacterListRoute(
 //                                        onDetailClick = { topLevelBackStack.add(HomeDetail) },
-//                                        modifier = screenModifier
+                                    modifier = screenModifier
                                 )
                             }
                             entry<CharacterDetail> {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,7 +1,26 @@
 plugins {
-    kotlin("jvm")
+    kotlin("android")
+    alias(libs.plugins.android.library)
     alias(libs.plugins.devtools.ksp)
     alias(libs.plugins.jetbrains.kotlin.serialization)
+}
+
+android {
+    namespace = "com.yujin.data"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }
 
 java {
@@ -32,6 +51,9 @@ dependencies {
     //Hilt
     implementation(libs.hilt.core)
     ksp(libs.hilt.android.compiler)
+
+    //paging
+    implementation(libs.androidx.paging.runtime)
 
     // 테스트
     testImplementation(kotlin("test"))

--- a/data/src/main/java/com/yujin/data/paging/CharacterPagingSource.kt
+++ b/data/src/main/java/com/yujin/data/paging/CharacterPagingSource.kt
@@ -1,29 +1,26 @@
-package com.yujin.presentation.characterlist.paging
+package com.yujin.data.paging
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.yujin.data.api.RickAndMortyApi
+import com.yujin.data.mapper.toDomain
 import com.yujin.domain.model.Character
-import com.yujin.domain.repository.CharacterRepository
 
 class CharacterPagingSource(
-    private val repository: CharacterRepository
+    private val api: RickAndMortyApi
 ) : PagingSource<Int, Character>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Character> {
         return try {
             val page = params.key ?: 1
 
-            repository.getAllCharacters(page).fold(
-                onSuccess = { response ->
-                    LoadResult.Page(
-                        data = response.results,
-                        prevKey = if (page == 1) null else page - 1,
-                        nextKey = if (response.info.next == null) null else page + 1
-                    )
-                },
-                onFailure = { error ->
-                    LoadResult.Error(error)
-                }
+            val response = api.getAllCharacters(page)
+            val characters = response.results.map { it.toDomain() }
+
+            LoadResult.Page(
+                data = characters,
+                prevKey = if (page == 1) null else page - 1,
+                nextKey = if (response.info.next == null) null else page + 1
             )
         } catch (e: Exception) {
             LoadResult.Error(e)

--- a/data/src/main/java/com/yujin/data/repository/CharacterRepositoryImpl.kt
+++ b/data/src/main/java/com/yujin/data/repository/CharacterRepositoryImpl.kt
@@ -10,7 +10,9 @@ import com.yujin.domain.model.Character
 import com.yujin.domain.model.CharacterFilter
 import com.yujin.domain.model.CharacterResponse
 import com.yujin.domain.repository.CharacterRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 
 class CharacterRepositoryImpl(
     private val api: RickAndMortyApi
@@ -20,10 +22,11 @@ class CharacterRepositoryImpl(
         return Pager(
             config = PagingConfig(
                 pageSize = 20,
-                enablePlaceholders = false
+                enablePlaceholders = false,
+                prefetchDistance = 3 // 3개 남으면 추가로드
             ),
-            pagingSourceFactory = { CharacterPagingSource(api) }
-        ).flow
+            pagingSourceFactory = { CharacterPagingSource(api) } // Paging은 내부적으로 데이터가 갱신될 떄마다 PagingSource를 새로 생성해서 사용해서 이를 위한 매번 인스턴스를 새로 생성할 람다가 필요함
+        ).flow.flowOn(Dispatchers.IO)  //데이터 요청은 IO
     }
 
     override suspend fun getCharacterById(id: Int): Result<Character> {

--- a/data/src/main/java/com/yujin/data/repository/CharacterRepositoryImpl.kt
+++ b/data/src/main/java/com/yujin/data/repository/CharacterRepositoryImpl.kt
@@ -18,10 +18,14 @@ class CharacterRepositoryImpl(
     private val api: RickAndMortyApi
 ) : CharacterRepository {
 
+    companion object {
+        private const val DEFAULT_PAGE_SIZE = 20
+    }
+
     override fun getAllCharacters(): Flow<PagingData<Character>> {
         return Pager(
             config = PagingConfig(
-                pageSize = 20,
+                pageSize = DEFAULT_PAGE_SIZE,
                 enablePlaceholders = false,
                 prefetchDistance = 3 // 3개 남으면 추가로드
             ),

--- a/data/src/main/java/com/yujin/data/repository/CharacterRepositoryImpl.kt
+++ b/data/src/main/java/com/yujin/data/repository/CharacterRepositoryImpl.kt
@@ -1,20 +1,29 @@
 package com.yujin.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import com.yujin.data.api.RickAndMortyApi
 import com.yujin.data.mapper.toDomain
+import com.yujin.data.paging.CharacterPagingSource
 import com.yujin.domain.model.Character
 import com.yujin.domain.model.CharacterFilter
 import com.yujin.domain.model.CharacterResponse
 import com.yujin.domain.repository.CharacterRepository
+import kotlinx.coroutines.flow.Flow
 
 class CharacterRepositoryImpl(
     private val api: RickAndMortyApi
 ) : CharacterRepository {
 
-    override suspend fun getAllCharacters(page: Int): Result<CharacterResponse> {
-        return runCatching {
-            api.getAllCharacters(page).toDomain()
-        }
+    override fun getAllCharacters(): Flow<PagingData<Character>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = 20,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = { CharacterPagingSource(api) }
+        ).flow
     }
 
     override suspend fun getCharacterById(id: Int): Result<Character> {
@@ -31,5 +40,7 @@ class CharacterRepositoryImpl(
             api.searchCharacters(filter, page).toDomain()
         }
     }
+
+
 }
 

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -11,6 +11,7 @@ java {
 dependencies {
     // Hilt
     implementation(libs.hilt.core)
+    implementation(libs.androidx.paging.common)
     
     testImplementation(kotlin("test"))
 }

--- a/domain/src/main/java/com/yujin/domain/repository/CharacterRepository.kt
+++ b/domain/src/main/java/com/yujin/domain/repository/CharacterRepository.kt
@@ -1,11 +1,13 @@
 package com.yujin.domain.repository
 
+import androidx.paging.PagingData
 import com.yujin.domain.model.Character
 import com.yujin.domain.model.CharacterFilter
 import com.yujin.domain.model.CharacterResponse
+import kotlinx.coroutines.flow.Flow
 
 interface CharacterRepository {
-    suspend fun getAllCharacters(page: Int = 1): Result<CharacterResponse>
+    fun getAllCharacters(): Flow<PagingData<Character>>
     suspend fun getCharacterById(id: Int): Result<Character>
     suspend fun searchCharacters(filter: CharacterFilter, page: Int = 1): Result<CharacterResponse>
 }

--- a/domain/src/main/java/com/yujin/domain/usecase/GetAllCharactersUseCase.kt
+++ b/domain/src/main/java/com/yujin/domain/usecase/GetAllCharactersUseCase.kt
@@ -1,14 +1,16 @@
 package com.yujin.domain.usecase
 
-import com.yujin.domain.model.CharacterResponse
+import androidx.paging.PagingData
+import com.yujin.domain.model.Character
 import com.yujin.domain.repository.CharacterRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetAllCharactersUseCase @Inject constructor(
     private val repository: CharacterRepository
 ) {
-    suspend operator fun invoke(page: Int = 1): Result<CharacterResponse> {
-        return repository.getAllCharacters(page)
+    operator fun invoke(): Flow<PagingData<Character>> {
+        return repository.getAllCharacters()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
+androidx-paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
 
 # Hilt
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,15 +17,10 @@ lifecycleViewmodelNav3 = "2.10.0"
 material3AdaptiveNav3 = "1.3.0-alpha04"
 
 # Kotlin Serialization
-# plugin은 kotlin 버전과 동일, 라이브러리는 1.8.1
 kotlinxSerialization = "1.8.1"
 
-retrofit = "2.9.0"
-okhttp = "4.12.0"
 coil = "2.5.0"
 paging = "3.3.0"
-
-appcompat = "1.7.1"
 
 # Hilt
 hiltAndroid = "2.51.1"
@@ -34,7 +29,6 @@ ksp = "2.0.20-1.0.24"
 
 # Ktor
 ktor = "2.3.5" # 하나로 통일
-ktorOldSerialization = "1.6.3"
 
 # Timber
 timber = "5.0.1"
@@ -73,8 +67,6 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-
 # Hilt
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hiltAndroid" }
@@ -101,7 +93,6 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
-# serialization plugin은 kotlin 버전과 동일해야 함
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hiltAndroid" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -67,7 +67,5 @@ dependencies {
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
-    // Data 모듈 (Repository 구현체 사용)
-    implementation(project(":data"))
     implementation(project(":domain"))
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -63,5 +63,11 @@ dependencies {
     // Coil
     implementation(libs.coil.compose)
 
+    // Paging
+    implementation(libs.androidx.paging.runtime)
+    implementation(libs.androidx.paging.compose)
+
+    // Data 모듈 (Repository 구현체 사용)
+    implementation(project(":data"))
     implementation(project(":domain"))
 }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListContract.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListContract.kt
@@ -1,12 +1,16 @@
 package com.yujin.presentation.characterlist
 
+import androidx.paging.compose.LazyPagingItems
+import com.yujin.presentation.characterlist.model.CharacterUiModel
 import com.yujin.presentation.common.UiEvent
-import com.yujin.presentation.common.UiState
 
 /**
  * UI State that represents CharacterListScreen
+ * Paging의 경우 LazyPagingItems가 이미 상태를 포함하므로 별도 UiState 불필요
  **/
-typealias CharacterListState = UiState<Unit>
+data class CharacterListUiState(
+    val pagingItems: LazyPagingItems<CharacterUiModel>
+)
 
 /**
  * CharacterList Events emitted from the UI Layer

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListContract.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListContract.kt
@@ -1,26 +1,25 @@
 package com.yujin.presentation.characterlist
 
-import com.yujin.domain.model.Character
+import com.yujin.presentation.common.UiEvent
+import com.yujin.presentation.common.UiState
 
 /**
  * UI State that represents CharacterListScreen
  **/
-data class CharacterListState(
-    val characters: List<Character> = emptyList(),
-    val isLoading: Boolean = false,
-    val error: String? = null,
-    val currentPage: Int = 1,
-    val hasNextPage: Boolean = true
-)
+typealias CharacterListState = UiState<Unit>
+
+/**
+ * CharacterList Events emitted from the UI Layer
+ * passed to the coordinator to handle
+ **/
+sealed interface CharacterListEvent : UiEvent {
+    data class NavigateToDetail(val characterId: Int) : CharacterListEvent
+}
 
 /**
  * CharacterList Actions emitted from the UI Layer
  * passed to the coordinator to handle
  **/
 data class CharacterListActions(
-    val onCharacterClick: (Int) -> Unit = {},
-    val onLoadMore: () -> Unit = {},
-    val onRetry: () -> Unit = {}
+    val onCharacterClick: (Int) -> Unit = {}
 )
-
-

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListCoordinator.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListCoordinator.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
-import com.yujin.domain.model.Character
+import com.yujin.presentation.characterlist.model.CharacterUiModel
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -14,8 +14,7 @@ import kotlinx.coroutines.flow.Flow
 class CharacterListCoordinator(
     val viewModel: CharacterListViewModel
 ) {
-    val screenStateFlow = viewModel.stateFlow
-    val characters: Flow<PagingData<Character>> = viewModel.characters
+    val characters: Flow<PagingData<CharacterUiModel>> = viewModel.characters
 
     fun handleEvent(event: CharacterListEvent) {
         when (event) {

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListCoordinator.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListCoordinator.kt
@@ -3,6 +3,9 @@ package com.yujin.presentation.characterlist
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.PagingData
+import com.yujin.domain.model.Character
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Screen's coordinator which is responsible for handling actions from the UI layer
@@ -12,17 +15,14 @@ class CharacterListCoordinator(
     val viewModel: CharacterListViewModel
 ) {
     val screenStateFlow = viewModel.stateFlow
+    val characters: Flow<PagingData<Character>> = viewModel.characters
 
-    fun onCharacterClick(characterId: Int) {
-        // TODO: Navigate to character detail
-    }
-
-    fun onLoadMore() {
-        viewModel.loadMore()
-    }
-
-    fun onRetry() {
-        viewModel.retry()
+    fun handleEvent(event: CharacterListEvent) {
+        when (event) {
+            is CharacterListEvent.NavigateToDetail -> {
+                // TODO: Navigate to character detail
+            }
+        }
     }
 }
 

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListRoute.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListRoute.kt
@@ -4,12 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.yujin.presentation.common.UiState
 
 
 @Composable
 fun CharacterListRoute(
+    modifier: Modifier,
     coordinator: CharacterListCoordinator = rememberCharacterListCoordinator()
 ) {
     // State observing and declarations
@@ -20,7 +22,7 @@ fun CharacterListRoute(
     val actions = rememberCharacterListActions(coordinator)
 
     // UI Rendering
-    CharacterListScreen(uiState, actions, pagingItems)
+    CharacterListScreen(uiState, actions, pagingItems, modifier)
 }
 
 

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListRoute.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListRoute.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.yujin.presentation.common.UiState
 
 
 @Composable
@@ -11,13 +13,14 @@ fun CharacterListRoute(
     coordinator: CharacterListCoordinator = rememberCharacterListCoordinator()
 ) {
     // State observing and declarations
-    val uiState by coordinator.screenStateFlow.collectAsState(CharacterListState())
+    val uiState by coordinator.screenStateFlow.collectAsState(UiState.Init)
+    val pagingItems = coordinator.characters.collectAsLazyPagingItems()
 
     // UI Actions
     val actions = rememberCharacterListActions(coordinator)
 
     // UI Rendering
-    CharacterListScreen(uiState, actions)
+    CharacterListScreen(uiState, actions, pagingItems)
 }
 
 
@@ -25,9 +28,9 @@ fun CharacterListRoute(
 fun rememberCharacterListActions(coordinator: CharacterListCoordinator): CharacterListActions {
     return remember(coordinator) {
         CharacterListActions(
-            onCharacterClick = coordinator::onCharacterClick,
-            onLoadMore = coordinator::onLoadMore,
-            onRetry = coordinator::onRetry
+            onCharacterClick = { characterId ->
+                coordinator.handleEvent(CharacterListEvent.NavigateToDetail(characterId))
+            }
         )
     }
 }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListRoute.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListRoute.kt
@@ -1,12 +1,9 @@
 package com.yujin.presentation.characterlist
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.yujin.presentation.common.UiState
 
 
 @Composable
@@ -15,14 +12,14 @@ fun CharacterListRoute(
     coordinator: CharacterListCoordinator = rememberCharacterListCoordinator()
 ) {
     // State observing and declarations
-    val uiState by coordinator.screenStateFlow.collectAsState(UiState.Init)
     val pagingItems = coordinator.characters.collectAsLazyPagingItems()
+    val uiState = CharacterListUiState(pagingItems = pagingItems)
 
     // UI Actions
     val actions = rememberCharacterListActions(coordinator)
 
     // UI Rendering
-    CharacterListScreen(uiState, actions, pagingItems, modifier)
+    CharacterListScreen(uiState, actions, modifier)
 }
 
 

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
@@ -4,55 +4,36 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
 import com.yujin.domain.model.Character
+import com.yujin.presentation.characterlist.components.CharacterItem
+import com.yujin.presentation.common.UiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CharacterListScreen(
-    state: CharacterListState,
-    actions: CharacterListActions
+internal fun CharacterListScreen(
+    state: UiState<Unit>,
+    actions: CharacterListActions,
+    pagingItems: LazyPagingItems<Character>
 ) {
-    val listState = rememberLazyListState()
-
-    // 스크롤이 끝에 가까워지면 더 불러오기
-    LaunchedEffect(listState) {
-        val layoutInfo = listState.layoutInfo
-        val lastVisibleItem = layoutInfo.visibleItemsInfo.lastOrNull()
-        if (lastVisibleItem != null &&
-            lastVisibleItem.index >= layoutInfo.totalItemsCount - 3 &&
-            state.hasNextPage &&
-            !state.isLoading
-        ) {
-            actions.onLoadMore()
-        }
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -63,106 +44,87 @@ fun CharacterListScreen(
         }
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
-            when {
-                state.characters.isEmpty() && state.isLoading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
-                    }
-                }
-
-                state.error != null -> {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
-                    ) {
-                        Text(text = "Error: ${state.error}")
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "Retry",
-                            modifier = Modifier.clickable { actions.onRetry() }
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(
+                    count = pagingItems.itemCount,
+                    key = pagingItems.itemKey { it.id }
+                ) { index ->
+                    val character = pagingItems[index]
+                    if (character != null) {
+                        CharacterItem(
+                            character = character,
+                            onClick = { actions.onCharacterClick(character.id) }
                         )
                     }
                 }
 
-                else -> {
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        items(
-                            items = state.characters,
-                            key = { it.id }
-                        ) { character ->
-                            CharacterItem(
-                                character = character,
-                                onClick = { actions.onCharacterClick(character.id) }
-                            )
+                // 로딩 상태 표시
+                if (pagingItems.loadState.append is LoadState.Loading) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
                         }
+                    }
+                }
 
-                        if (state.isLoading && state.characters.isNotEmpty()) {
-                            item {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(16.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    CircularProgressIndicator()
-                                }
-                            }
+                // 에러 상태 표시
+                if (pagingItems.loadState.append is LoadState.Error) {
+                    item {
+                        val error = (pagingItems.loadState.append as LoadState.Error).error
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(text = "Error: ${error.message}")
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "Retry",
+                                modifier = Modifier.clickable { pagingItems.retry() }
+                            )
                         }
                     }
                 }
             }
-        }
-    }
-}
 
-@Composable
-fun CharacterItem(
-    character: Character,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            AsyncImage(
-                model = character.image,
-                contentDescription = character.name,
-                modifier = Modifier
-                    .size(80.dp),
-                contentScale = ContentScale.Crop
-            )
+            // 초기 로딩 상태
+            if (pagingItems.loadState.refresh is LoadState.Loading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
 
-            Spacer(modifier = Modifier.width(12.dp))
-
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = character.name,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(text = "Status: ${character.status}")
-                Text(text = "Gender: ${character.gender}")
+            // 초기 에러 상태
+            if (pagingItems.loadState.refresh is LoadState.Error) {
+                val error = (pagingItems.loadState.refresh as LoadState.Error).error
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(text = "Error: ${error.message}")
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "Retry",
+                            modifier = Modifier.clickable { pagingItems.retry() }
+                        )
+                    }
+                }
             }
         }
     }
@@ -171,26 +133,5 @@ fun CharacterItem(
 @Composable
 @Preview(name = "CharacterList")
 private fun CharacterListScreenPreview() {
-    CharacterListScreen(
-        state = CharacterListState(
-            characters = listOf(
-                Character(
-                    id = 1,
-                    name = "Rick Sanchez",
-                    status = "Alive",
-                    species = "Human",
-                    type = "",
-                    gender = "Male",
-                    origin = com.yujin.domain.model.Location("Earth", ""),
-                    location = com.yujin.domain.model.Location("Earth", ""),
-                    image = "",
-                    episode = emptyList(),
-                    url = "",
-                    created = ""
-                )
-            )
-        ),
-        actions = CharacterListActions()
-    )
+    // Preview는 PagingItems 없이 표시할 수 없으므로 제거
 }
-

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -32,7 +31,8 @@ import com.yujin.presentation.common.UiState
 internal fun CharacterListScreen(
     state: UiState<Unit>,
     actions: CharacterListActions,
-    pagingItems: LazyPagingItems<Character>
+    pagingItems: LazyPagingItems<Character>,
+    modifier: Modifier,
 ) {
     Scaffold(
         topBar = {
@@ -43,7 +43,7 @@ internal fun CharacterListScreen(
             )
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
+        Box(modifier = modifier.padding(innerPadding)) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
@@ -128,10 +128,4 @@ internal fun CharacterListScreen(
             }
         }
     }
-}
-
-@Composable
-@Preview(name = "CharacterList")
-private fun CharacterListScreenPreview() {
-    // Preview는 PagingItems 없이 표시할 수 없으므로 제거
 }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
@@ -20,20 +20,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
-import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
-import com.yujin.domain.model.Character
 import com.yujin.presentation.characterlist.components.CharacterItem
-import com.yujin.presentation.common.UiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun CharacterListScreen(
-    state: UiState<Unit>,
+    state: CharacterListUiState,
     actions: CharacterListActions,
-    pagingItems: LazyPagingItems<Character>,
     modifier: Modifier,
 ) {
+    val pagingItems = state.pagingItems
     Scaffold(
         topBar = {
             TopAppBar(

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListScreen.kt
@@ -1,16 +1,11 @@
 package com.yujin.presentation.characterlist
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -22,6 +17,8 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.itemKey
 import com.yujin.presentation.characterlist.components.CharacterItem
+import com.yujin.presentation.characterlist.components.ErrorStateItem
+import com.yujin.presentation.characterlist.components.LoadingIndicatorItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -62,14 +59,11 @@ internal fun CharacterListScreen(
                 // 로딩 상태 표시
                 if (pagingItems.loadState.append is LoadState.Loading) {
                     item {
-                        Box(
+                        LoadingIndicatorItem(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(16.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            CircularProgressIndicator()
-                        }
+                                .padding(16.dp)
+                        )
                     }
                 }
 
@@ -77,31 +71,22 @@ internal fun CharacterListScreen(
                 if (pagingItems.loadState.append is LoadState.Error) {
                     item {
                         val error = (pagingItems.loadState.append as LoadState.Error).error
-                        Column(
+                        ErrorStateItem(
+                            error = error,
+                            onRetry = { pagingItems.retry() },
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(16.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Text(text = "Error: ${error.message}")
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = "Retry",
-                                modifier = Modifier.clickable { pagingItems.retry() }
-                            )
-                        }
+                                .padding(16.dp)
+                        )
                     }
                 }
             }
 
             // 초기 로딩 상태
             if (pagingItems.loadState.refresh is LoadState.Loading) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
+                LoadingIndicatorItem(
+                    modifier = Modifier.fillMaxSize()
+                )
             }
 
             // 초기 에러 상태
@@ -111,16 +96,11 @@ internal fun CharacterListScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(text = "Error: ${error.message}")
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "Retry",
-                            modifier = Modifier.clickable { pagingItems.retry() }
-                        )
-                    }
+                    ErrorStateItem(
+                        error = error,
+                        onRetry = { pagingItems.retry() },
+                        spacing = 16.dp
+                    )
                 }
             }
         }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListViewModel.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListViewModel.kt
@@ -3,39 +3,26 @@ package com.yujin.presentation.characterlist
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import com.yujin.domain.repository.CharacterRepository
-import com.yujin.presentation.characterlist.paging.CharacterPagingSource
-import com.yujin.presentation.common.UiState
+import androidx.paging.map
+import com.yujin.domain.usecase.GetAllCharactersUseCase
+import com.yujin.presentation.characterlist.model.CharacterUiModel
+import com.yujin.presentation.characterlist.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @HiltViewModel
 class CharacterListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val characterRepository: CharacterRepository
+    private val getAllCharactersUseCase: GetAllCharactersUseCase
 ) : ViewModel() {
 
-    val characters = Pager(
-        config = PagingConfig(
-            pageSize = 20,
-            enablePlaceholders = false
-        ),
-        pagingSourceFactory = { CharacterPagingSource(characterRepository) }
-    ).flow
+    val characters: Flow<PagingData<CharacterUiModel>> = getAllCharactersUseCase()
+        .map { pagingData ->
+            pagingData.map { character -> character.toUiModel() }
+        }
         .cachedIn(viewModelScope)
-
-    private val _stateFlow: MutableStateFlow<CharacterListState> =
-        MutableStateFlow(UiState.Init)
-
-    val stateFlow: StateFlow<CharacterListState> = _stateFlow.asStateFlow()
-
-    init {
-        _stateFlow.value = UiState.Success(Unit)
-    }
 }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListViewModel.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/CharacterListViewModel.kt
@@ -3,69 +3,39 @@ package com.yujin.presentation.characterlist
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.yujin.domain.usecase.GetAllCharactersUseCase
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.cachedIn
+import com.yujin.domain.repository.CharacterRepository
+import com.yujin.presentation.characterlist.paging.CharacterPagingSource
+import com.yujin.presentation.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CharacterListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val getAllCharactersUseCase: GetAllCharactersUseCase
+    private val characterRepository: CharacterRepository
 ) : ViewModel() {
 
+    val characters = Pager(
+        config = PagingConfig(
+            pageSize = 20,
+            enablePlaceholders = false
+        ),
+        pagingSourceFactory = { CharacterPagingSource(characterRepository) }
+    ).flow
+        .cachedIn(viewModelScope)
+
     private val _stateFlow: MutableStateFlow<CharacterListState> =
-        MutableStateFlow(CharacterListState())
+        MutableStateFlow(UiState.Init)
 
     val stateFlow: StateFlow<CharacterListState> = _stateFlow.asStateFlow()
 
     init {
-        loadCharacters()
-    }
-
-    fun loadCharacters(page: Int = 1) {
-        viewModelScope.launch {
-            _stateFlow.update { it.copy(isLoading = true, error = null) }
-
-            getAllCharactersUseCase(page).fold(
-                onSuccess = { response ->
-                    _stateFlow.update { currentState ->
-                        currentState.copy(
-                            characters = if (page == 1) {
-                                response.results
-                            } else {
-                                currentState.characters + response.results
-                            },
-                            isLoading = false,
-                            currentPage = page,
-                            hasNextPage = response.info.next != null
-                        )
-                    }
-                },
-                onFailure = { error ->
-                    _stateFlow.update {
-                        it.copy(
-                            isLoading = false,
-                            error = error.message ?: "Unknown error"
-                        )
-                    }
-                }
-            )
-        }
-    }
-
-    fun loadMore() {
-        val currentState = _stateFlow.value
-        if (!currentState.isLoading && currentState.hasNextPage) {
-            loadCharacters(currentState.currentPage + 1)
-        }
-    }
-
-    fun retry() {
-        loadCharacters(_stateFlow.value.currentPage)
+        _stateFlow.value = UiState.Success(Unit)
     }
 }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/components/CharacterItem.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/components/CharacterItem.kt
@@ -1,0 +1,63 @@
+package com.yujin.presentation.characterlist.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.yujin.domain.model.Character
+
+@Composable
+fun CharacterItem(
+    character: Character,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = character.image,
+                contentDescription = character.name,
+                modifier = Modifier
+                    .size(80.dp),
+                contentScale = ContentScale.Crop
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = character.name,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(text = "Status: ${character.status}")
+                Text(text = "Gender: ${character.gender}")
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/components/CharacterItem.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/components/CharacterItem.kt
@@ -16,13 +16,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.yujin.domain.model.Character
+import com.yujin.presentation.characterlist.model.CharacterUiModel
+import com.yujin.presentation.ui.theme.RickAndMortyTheme
 
 @Composable
 fun CharacterItem(
-    character: Character,
+    character: CharacterUiModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -59,5 +61,24 @@ fun CharacterItem(
                 Text(text = "Gender: ${character.gender}")
             }
         }
+    }
+}
+
+
+@Composable
+@Preview
+fun CharacterItemPreview() {
+    RickAndMortyTheme {
+        CharacterItem(
+            character = CharacterUiModel(
+                id = 1,
+                name = "Rick Sanchez",
+                status = "Alive",
+                gender = "Male",
+                image = "https://rickandmortyapi.com/api/character",
+            ),
+            onClick = { },
+            modifier = Modifier,
+        )
     }
 }

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/components/ErrorStateItem.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/components/ErrorStateItem.kt
@@ -1,0 +1,31 @@
+package com.yujin.presentation.characterlist.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun ErrorStateItem(
+    error: Throwable,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+    spacing: androidx.compose.ui.unit.Dp = 8.dp
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Error: ${error.message}")
+        Spacer(modifier = Modifier.height(spacing))
+        Text(
+            text = "Retry",
+            modifier = Modifier.clickable { onRetry() }
+        )
+    }
+}

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/components/LoadingIndicatorItem.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/components/LoadingIndicatorItem.kt
@@ -1,0 +1,20 @@
+package com.yujin.presentation.characterlist.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+internal fun LoadingIndicatorItem(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/model/CharacterUiModel.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/model/CharacterUiModel.kt
@@ -1,0 +1,24 @@
+package com.yujin.presentation.characterlist.model
+
+import com.yujin.domain.model.Character
+
+data class CharacterUiModel(
+    val id: Int,
+    val name: String,
+    val status: String,
+    val gender: String,
+    val image: String,
+)
+
+
+fun Character.toUiModel(): CharacterUiModel {
+    return CharacterUiModel(
+        id = id,
+        name = name,
+        status = status,
+        gender = gender,
+        image = image,
+    )
+}
+
+

--- a/presentation/src/main/java/com/yujin/presentation/characterlist/paging/CharacterPagingSource.kt
+++ b/presentation/src/main/java/com/yujin/presentation/characterlist/paging/CharacterPagingSource.kt
@@ -1,0 +1,40 @@
+package com.yujin.presentation.characterlist.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.yujin.domain.model.Character
+import com.yujin.domain.repository.CharacterRepository
+
+class CharacterPagingSource(
+    private val repository: CharacterRepository
+) : PagingSource<Int, Character>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Character> {
+        return try {
+            val page = params.key ?: 1
+
+            repository.getAllCharacters(page).fold(
+                onSuccess = { response ->
+                    LoadResult.Page(
+                        data = response.results,
+                        prevKey = if (page == 1) null else page - 1,
+                        nextKey = if (response.info.next == null) null else page + 1
+                    )
+                },
+                onFailure = { error ->
+                    LoadResult.Error(error)
+                }
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Character>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+}
+

--- a/presentation/src/main/java/com/yujin/presentation/common/UiEvent.kt
+++ b/presentation/src/main/java/com/yujin/presentation/common/UiEvent.kt
@@ -1,0 +1,6 @@
+package com.yujin.presentation.common
+
+interface UiEvent {
+    data class ShowToast(val message: String) : UiEvent
+    object NavigateBack : UiEvent
+}

--- a/presentation/src/main/java/com/yujin/presentation/common/UiState.kt
+++ b/presentation/src/main/java/com/yujin/presentation/common/UiState.kt
@@ -1,0 +1,13 @@
+package com.yujin.presentation.common
+
+sealed interface UiState<out T> {
+    object Init : UiState<Nothing>
+
+    object Loading : UiState<Nothing>
+
+    data class Success<out T>(
+        val data: T,
+    ) : UiState<T>
+
+    object Error : UiState<Nothing>
+}


### PR DESCRIPTION
## 작업 내용
- resolved #5 

## 변경 사항 요약
- Paging3 라이브러리를 활용하여 무한 스크롤 구현
  Paging3 라이브러리를 클린아키텍쳐에 맞게 쪼개서 구현
  data 모듈을 순수 kotlin 모듈에서 안드로이드 모듈로 변경함
- MainActivity의 modifier를 넘겨서 여백을 줌
- CharacterItem 컴포넌트 파일 분리

[Screen_recording_20251209_192538.webm](https://github.com/user-attachments/assets/a420bf0c-87a1-4c24-971e-e95223d86f24)
